### PR TITLE
Fixed the issue that AvatarPanel is loaded before joining a room. Now…

### DIFF
--- a/Assets/Scripts/LaunchManager.cs
+++ b/Assets/Scripts/LaunchManager.cs
@@ -97,9 +97,7 @@ public class LaunchManager : MonoBehaviourPunCallbacks {
         Debug.Log("Connected! " + PhotonNetwork.NickName);
         Debug.Log("Is creating new event: " + createNew);
         Debug.Log("Is joining existing event: " + joinExisting);
-        ConnectionStatusPanel.SetActive(false);
         if (createNew) {
-            AvatarPanel.SetActive(true);
             CreateAndJoinRoom();
         } else if (joinExisting) {
             DisplayPasscodePanel();
@@ -125,6 +123,7 @@ public class LaunchManager : MonoBehaviourPunCallbacks {
             EnterPasscodePanel.SetActive(false);
         }
         AvatarPanel.SetActive(true);
+        ConnectionStatusPanel.SetActive(false);
     }
 
     public override void OnPlayerEnteredRoom(Player newPlayer)


### PR DESCRIPTION
### LaunchManager
1. ConnectionStatusPanel should be set inactive and AvatarPanel should be set active only after room is successfully joined, otherwise the user can start loading the level before they joined a room.

### Testing
1. Manually tested that quickly entering the game at the Avatar Menu does not cause loading issues.