### PR TITLE
Fixed a mistake where the RPC doesn't call the "reset poster image" function

### DIFF
--- a/Assets/Scripts/BoothSetup.cs
+++ b/Assets/Scripts/BoothSetup.cs
@@ -116,7 +116,6 @@ public class BoothSetup : MonoBehaviourPunCallbacks {
     public void ResetBooth() {
         __isOwner = false;
         __photonView.RPC("ClearBooth", RpcTarget.AllBuffered);
-        posterBoard.GetComponent<MeshRenderer>().material = defaultPosterMaterial;
     }
 
     [PunRPC]
@@ -126,5 +125,6 @@ public class BoothSetup : MonoBehaviourPunCallbacks {
         }
         boothText.text = string.Empty;
         __AssignBoothValues(string.Empty, string.Empty, string.Empty, string.Empty);
+        posterBoard.GetComponent<MeshRenderer>().material = defaultPosterMaterial;
     }
 }


### PR DESCRIPTION
### BoothSetup
- Fixed an error where the RPC doesn't actually call the helper function to reset the poster image, causing poster image to remain on the screen for everyone other than the previous booth owner

### Testing
1. Manual testing: I logged in as two users, set up the booth with a poster image and reset the booth and saw that the poster image was updated in both states by both users.
2. New build: http://web.engr.oregonstate.edu/~wukev/index.html