### PR TITLE
Fixed an issue where user model persists even after they disconnect.

### DIFF
--- a/Assets/Resources/UserFemale.prefab
+++ b/Assets/Resources/UserFemale.prefab
@@ -325,7 +325,7 @@ GameObject:
   - component: {fileID: 1346584965419313239}
   m_Layer: 0
   m_Name: UserFemale
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -460,6 +460,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   FPSCamera: {fileID: 8489506943346519909}
   userNameText: {fileID: 5042292178510995893}
+  user: {fileID: 6601386651165192743}
 --- !u!143 &1346584965419313239
 CharacterController:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/UserMale.prefab
+++ b/Assets/Resources/UserMale.prefab
@@ -1014,7 +1014,7 @@ GameObject:
   - component: {fileID: 196389606}
   m_Layer: 0
   m_Name: UserMale
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1109,6 +1109,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   FPSCamera: {fileID: 2537268446147669783}
   userNameText: {fileID: 3482946811446856652}
+  user: {fileID: 2537268446203303740}
 --- !u!114 &1193339298232331860
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/ExpoEventManager.cs
+++ b/Assets/Scripts/ExpoEventManager.cs
@@ -34,6 +34,16 @@ public class ExpoEventManager : MonoBehaviourPunCallbacks {
         PhotonNetwork.LoadLevel("EventLauncherScene");
     }
 
+    public override void OnPlayerLeftRoom(Player otherPlayer) {
+        foreach (GameObject user in GameObject.FindGameObjectsWithTag("Player")) {
+            PhotonView photonView = user.GetPhotonView();
+            if (photonView.Owner == null || photonView.Owner.NickName == otherPlayer.NickName) {
+                photonView.RPC("RemoveUser", RpcTarget.AllBuffered);
+                break;
+            }
+        }
+    }
+
     public void DisplayAvatarPanel() {
         AvatarPanel.SetActive(true);
         UnselectedAvatarText.SetActive(false);

--- a/Assets/Scripts/UserSetup.cs
+++ b/Assets/Scripts/UserSetup.cs
@@ -10,7 +10,7 @@ public class UserSetup : MonoBehaviourPunCallbacks {
 
     [SerializeField]
     TextMeshProUGUI userNameText;
-
+    public GameObject user;
     private CharacterController __characterController;
 
     // Start is called before the first frame update
@@ -48,4 +48,8 @@ public class UserSetup : MonoBehaviourPunCallbacks {
         }
     }
 
+    [PunRPC]
+    public void RemoveUser() {
+        Destroy(user);
+    }
 }


### PR DESCRIPTION
### ExpoEventManager
- Added a callback function for when a player leaves a room, the GameObject associated with it is found and is removed via a RPC.

### UserInfo
- Added a user GameObject and a RPC to remove it.

### Assets
- Updated UserFemale and UserMale: their UserInfo script now references themselves, and added a tag "Player".

### Testing
1. Manual testing: I logged in as two users and tested out whether user models persist after users disconnected (via the exit event button or refreshing/closing the browser) - they didn't.
2. New build: http://web.engr.oregonstate.edu/~wukev/index.html