### PR TITLE
Fixed an issue that resetting booth poster image wasn't working correctly for newly joined users.

### DIFF
--- a/Assets/Scripts/BoothSetup.cs
+++ b/Assets/Scripts/BoothSetup.cs
@@ -10,7 +10,6 @@ using UnityEngine.Networking;
 public class BoothSetup : MonoBehaviourPunCallbacks {
     public TextMeshProUGUI boothText;
     public GameObject posterBoard;
-    public Material defaultPosterMaterial;
     private PanelManager __panelManager;
     private ChatManager __chatManager;
     private PhotonView __photonView;
@@ -129,6 +128,6 @@ public class BoothSetup : MonoBehaviourPunCallbacks {
         }
         boothText.text = string.Empty;
         __AssignBoothValues(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty);
-        posterBoard.GetComponent<MeshRenderer>().material = defaultPosterMaterial;
+        StartCoroutine(__SetPosterTexture("https://i.imgur.com/EFfwKyC.png"));
     }
 }


### PR DESCRIPTION
### BoothSetup
1. Resetting booth poster to default poster wasn't working in RPC for the user who later joins the room. I believe this was due to the StartCoroutine call finishing after a frame or two after the setup RPC is called. I think what's happening is that when someone sets up a booth and uses a custom image, then resets the booth to use the default poster image, all of those RPC is queued up for the next person who joins the room. When that person joins the room, the RPCs will run in sequence (set up poster image --> reset poster image to default), which is what we want. However, since the StartCoroutine call finishes a frame or two after it is called, setting the poster to default image will happen first, causing the poster image to be still using the custom poster image despite the booth having been reset.
2. I was able to solve this by not loading the default poster image directly but by loading the image from external website.

### Testing
1. I verified that booth is being reset by first logging in as a user, setting up and resetting a booth, and then logging in as a second user.
2. New build: http://web.engr.oregonstate.edu/~wukev/index.html