### PR TITLE
Add Main Menu Button to Passcode and Avatar Panel

### DIFF
--- a/Assets/Scenes/EventLauncherScene.unity
+++ b/Assets/Scenes/EventLauncherScene.unity
@@ -478,11 +478,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ae53c954c32638f498f64e013f0f7a41, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  enterEventPanel: {fileID: 513309119}
-  connectionStatusPanel: {fileID: 1728783872}
-  enterPasscodePanel: {fileID: 91822394}
-  invalidPasscodeText: {fileID: 1598908103}
-  passcodeInputField: {fileID: 1014218877}
+  EnterEventPanel: {fileID: 513309119}
+  ConnectionStatusPanel: {fileID: 1728783872}
+  EnterPasscodePanel: {fileID: 91822394}
+  InvalidPasscodeText: {fileID: 1598908103}
+  PasscodeInputField: {fileID: 1014218877}
 --- !u!1 &385407703
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/EventLauncherScene.unity
+++ b/Assets/Scenes/EventLauncherScene.unity
@@ -482,6 +482,7 @@ MonoBehaviour:
   connectionStatusPanel: {fileID: 1728783872}
   enterPasscodePanel: {fileID: 91822394}
   invalidPasscodeText: {fileID: 1598908103}
+  passcodeInputField: {fileID: 1014218877}
 --- !u!1 &385407703
 GameObject:
   m_ObjectHideFlags: 0
@@ -518,8 +519,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -90}
-  m_SizeDelta: {x: 300, y: 50}
+  m_AnchoredPosition: {x: 220, y: 0}
+  m_SizeDelta: {x: 250, y: 75}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &385407705
 MonoBehaviour:
@@ -1033,8 +1034,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 550, y: 90}
+  m_AnchoredPosition: {x: -130, y: 0}
+  m_SizeDelta: {x: 425, y: 75}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1014218877
 MonoBehaviour:
@@ -1477,6 +1478,7 @@ RectTransform:
   - {fileID: 519102469}
   - {fileID: 1014218876}
   - {fileID: 385407704}
+  - {fileID: 1365324332}
   m_Father: {fileID: 91822395}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1692,6 +1694,136 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1357116903}
   m_CullTransparentMesh: 0
+--- !u!1 &1365324331
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1365324332}
+  - component: {fileID: 1365324335}
+  - component: {fileID: 1365324334}
+  - component: {fileID: 1365324333}
+  m_Layer: 5
+  m_Name: MainMenuButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1365324332
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1365324331}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1651270358}
+  m_Father: {fileID: 1306142801}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -90}
+  m_SizeDelta: {x: 400, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1365324333
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1365324331}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1365324334}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 329913328}
+        m_MethodName: DisplayMainMenu
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1365324334
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1365324331}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1365324335
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1365324331}
+  m_CullTransparentMesh: 0
 --- !u!1 &1598908103
 GameObject:
   m_ObjectHideFlags: 0
@@ -1769,6 +1901,84 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1598908103}
+  m_CullTransparentMesh: 0
+--- !u!1 &1651270357
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1651270358}
+  - component: {fileID: 1651270360}
+  - component: {fileID: 1651270359}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1651270358
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1651270357}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1365324332}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1651270359
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1651270357}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 35
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 3
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Back to Main Menu
+--- !u!222 &1651270360
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1651270357}
   m_CullTransparentMesh: 0
 --- !u!1 &1728783872
 GameObject:

--- a/Assets/Scenes/MainEventScene.unity
+++ b/Assets/Scenes/MainEventScene.unity
@@ -6062,6 +6062,7 @@ MonoBehaviour:
   listOfAvatars:
   - {fileID: 6601386651165192743, guid: 84cfbeaebaceac84c884bbb4eb7b6099, type: 3}
   - {fileID: 2537268446203303740, guid: 6f6fd950dc13a4148b948a70c7b7eec5, type: 3}
+  NameInputField: {fileID: 1268788400}
 --- !u!114 &727287418
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8088,6 +8089,84 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1105400777}
   m_CullTransparentMesh: 0
+--- !u!1 &1111324151
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1111324152}
+  - component: {fileID: 1111324154}
+  - component: {fileID: 1111324153}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1111324152
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1111324151}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1137247448}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1111324153
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1111324151}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 3
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Back To Main Menu
+--- !u!222 &1111324154
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1111324151}
+  m_CullTransparentMesh: 0
 --- !u!1 &1133197435
 GameObject:
   m_ObjectHideFlags: 0
@@ -8165,6 +8244,136 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1133197435}
+  m_CullTransparentMesh: 0
+--- !u!1 &1137247447
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1137247448}
+  - component: {fileID: 1137247451}
+  - component: {fileID: 1137247450}
+  - component: {fileID: 1137247449}
+  m_Layer: 5
+  m_Name: MainMenuButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1137247448
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1137247447}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1111324152}
+  m_Father: {fileID: 1888291109}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -150, y: -323}
+  m_SizeDelta: {x: 300, y: 54}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1137247449
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1137247447}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1137247450}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 727287417}
+        m_MethodName: DisplayMainMenu
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1137247450
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1137247447}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1137247451
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1137247447}
   m_CullTransparentMesh: 0
 --- !u!1 &1143599586
 GameObject:
@@ -9250,11 +9459,11 @@ RectTransform:
   m_Father: {fileID: 1888291109}
   m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.44, y: 0.175}
-  m_AnchorMax: {x: 0.56, y: 0.22}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 7, y: -350}
+  m_SizeDelta: {x: 300, y: 54}
+  m_Pivot: {x: 0, y: 0}
 --- !u!114 &1244528923
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -12532,7 +12741,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Enter
+  m_Text: Enter Event
 --- !u!222 &1582804654
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -14309,6 +14518,7 @@ RectTransform:
   - {fileID: 741935641}
   - {fileID: 2014867153}
   - {fileID: 1244528922}
+  - {fileID: 1137247448}
   m_Father: {fileID: 488221783}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -14907,10 +15117,10 @@ RectTransform:
   m_Father: {fileID: 1888291109}
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.32, y: 0.28}
-  m_AnchorMax: {x: 0.68, y: 0.32}
-  m_AnchoredPosition: {x: 0, y: 1.9999084}
-  m_SizeDelta: {x: 8, y: 6}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -250}
+  m_SizeDelta: {x: 700, y: 64}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2014867154
 MonoBehaviour:
@@ -15994,7 +16204,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 492985574518587468}
   m_HandleRect: {fileID: 492985574518587467}
   m_Direction: 0
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:

--- a/Assets/Scripts/ExpoEventManager.cs
+++ b/Assets/Scripts/ExpoEventManager.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using Photon.Pun;
 using Photon.Realtime;
+using UnityEngine.UI;
 
 public class ExpoEventManager : MonoBehaviourPunCallbacks {
 
@@ -11,6 +12,7 @@ public class ExpoEventManager : MonoBehaviourPunCallbacks {
     public GameObject NameIsAvailableText;
     public GameObject EnterNameText;
     public GameObject[] listOfAvatars;
+    public InputField NameInputField;
     public static string initialName;
     public static bool isNameInputTouched;
     public static bool isNameUpdated;
@@ -30,8 +32,7 @@ public class ExpoEventManager : MonoBehaviourPunCallbacks {
     }
 
     public override void OnLeftRoom() {
-        PhotonNetwork.Disconnect();
-        PhotonNetwork.LoadLevel("EventLauncherScene");
+        __ResetEvent();
     }
 
     public override void OnPlayerLeftRoom(Player otherPlayer) {
@@ -130,5 +131,26 @@ public class ExpoEventManager : MonoBehaviourPunCallbacks {
 
     public void OnClickAvatarSelection(int avatar) {
         __mySelectedAvatar = avatar;
+    }
+
+    public void DisplayMainMenu() {
+        LeaveEvent();
+        __ResetAvatarPanel();
+    }
+
+    private void __ResetAvatarPanel() {
+        AvatarPanel.SetActive(false);
+        UnselectedAvatarText.SetActive(false);
+        NameIsAvailableText.SetActive(false);
+        DuplicateNameText.SetActive(false);
+        EnterNameText.SetActive(false);
+        NameInputField.Select();
+        NameInputField.text = string.Empty;
+        __mySelectedAvatar = 2;
+    }
+
+    private void __ResetEvent() {
+        PhotonNetwork.Disconnect();
+        PhotonNetwork.LoadLevel("EventLauncherScene");
     }
 }

--- a/Assets/Scripts/LaunchManager.cs
+++ b/Assets/Scripts/LaunchManager.cs
@@ -4,11 +4,11 @@ using Photon.Realtime;
 using UnityEngine.UI;
 
 public class LaunchManager : MonoBehaviourPunCallbacks {
-    public GameObject enterEventPanel;
-    public GameObject connectionStatusPanel;
-    public GameObject enterPasscodePanel;
-    public GameObject invalidPasscodeText;
-    public InputField passcodeInputField;
+    public GameObject EnterEventPanel;
+    public GameObject ConnectionStatusPanel;
+    public GameObject EnterPasscodePanel;
+    public GameObject InvalidPasscodeText;
+    public InputField PasscodeInputField;
     private bool __joinExisting;
     private string __passcodeInput;
 
@@ -18,9 +18,9 @@ public class LaunchManager : MonoBehaviourPunCallbacks {
 
     private void __ConnectToPhotonServer() {
         __SetInitialName();
-        enterEventPanel.SetActive(false);
-        connectionStatusPanel.SetActive(true);
-        invalidPasscodeText.SetActive(false);
+        EnterEventPanel.SetActive(false);
+        ConnectionStatusPanel.SetActive(true);
+        InvalidPasscodeText.SetActive(false);
         PhotonNetwork.ConnectUsingSettings();
     }
 
@@ -81,22 +81,22 @@ public class LaunchManager : MonoBehaviourPunCallbacks {
 
     public void DisplayMainMenu() {
         __ResetPasscodePanel();
-        enterEventPanel.SetActive(true);
-        passcodeInputField.Select();
-        passcodeInputField.text = string.Empty;
+        EnterEventPanel.SetActive(true);
+        PasscodeInputField.Select();
+        PasscodeInputField.text = string.Empty;
         PhotonNetwork.Disconnect();
     }
 
     private void __ResetPasscodePanel() {
-        enterPasscodePanel.SetActive(false);
-        invalidPasscodeText.SetActive(false);
+        EnterPasscodePanel.SetActive(false);
+        InvalidPasscodeText.SetActive(false);
         __passcodeInput = string.Empty;
         __joinExisting = false;
     }
 
     private void __DisplayPasscodePanel() {
-        enterPasscodePanel.SetActive(true);
-        invalidPasscodeText.SetActive(false);
+        EnterPasscodePanel.SetActive(true);
+        InvalidPasscodeText.SetActive(false);
     }
 
     #region Photon Callbacks
@@ -110,7 +110,6 @@ public class LaunchManager : MonoBehaviourPunCallbacks {
         } else {
             __CreateAndJoinRoom();
         }
-        
     }
 
     // This method is called when we have internet connection (before OnConnectedToMaster)
@@ -121,7 +120,7 @@ public class LaunchManager : MonoBehaviourPunCallbacks {
     // Called when PhotonNetwork.JoinRoom fails
     public override void OnJoinRoomFailed(short returnCode, string message) {
         Debug.Log("joined room failed");
-        invalidPasscodeText.SetActive(true);
+        InvalidPasscodeText.SetActive(true);
     }
 
     public override void OnJoinedRoom() {

--- a/Assets/Scripts/LaunchManager.cs
+++ b/Assets/Scripts/LaunchManager.cs
@@ -1,12 +1,14 @@
 ﻿using UnityEngine;
 using Photon.Pun;
 using Photon.Realtime;
+using UnityEngine.UI;
 
 public class LaunchManager : MonoBehaviourPunCallbacks {
     public GameObject enterEventPanel;
     public GameObject connectionStatusPanel;
     public GameObject enterPasscodePanel;
     public GameObject invalidPasscodeText;
+    public InputField passcodeInputField;
     private bool __joinExisting;
     private string __passcodeInput;
 
@@ -17,8 +19,8 @@ public class LaunchManager : MonoBehaviourPunCallbacks {
     private void __ConnectToPhotonServer() {
         __SetInitialName();
         enterEventPanel.SetActive(false);
-
         connectionStatusPanel.SetActive(true);
+        invalidPasscodeText.SetActive(false);
         PhotonNetwork.ConnectUsingSettings();
     }
 
@@ -28,8 +30,10 @@ public class LaunchManager : MonoBehaviourPunCallbacks {
     }
 
     public void JoinCreatedRoom() {
-        __joinExisting = true;
-        __ConnectToPhotonServer();
+        if (!PhotonNetwork.IsConnected) {
+            __joinExisting = true;
+            __ConnectToPhotonServer();
+        }
     }
 
     private void __SetInitialName() {
@@ -75,6 +79,26 @@ public class LaunchManager : MonoBehaviourPunCallbacks {
         return Random.Range(1000, 9999);
     }
 
+    public void DisplayMainMenu() {
+        __ResetPasscodePanel();
+        enterEventPanel.SetActive(true);
+        passcodeInputField.Select();
+        passcodeInputField.text = string.Empty;
+        PhotonNetwork.Disconnect();
+    }
+
+    private void __ResetPasscodePanel() {
+        enterPasscodePanel.SetActive(false);
+        invalidPasscodeText.SetActive(false);
+        __passcodeInput = string.Empty;
+        __joinExisting = false;
+    }
+
+    private void __DisplayPasscodePanel() {
+        enterPasscodePanel.SetActive(true);
+        invalidPasscodeText.SetActive(false);
+    }
+
     #region Photon Callbacks
 
     public override void OnConnectedToMaster() {
@@ -82,8 +106,7 @@ public class LaunchManager : MonoBehaviourPunCallbacks {
         Debug.Log("Is joining existing event: " + __joinExisting);
 
         if (__joinExisting) {
-            enterPasscodePanel.SetActive(true);
-            invalidPasscodeText.SetActive(false);
+            __DisplayPasscodePanel();
         } else {
             __CreateAndJoinRoom();
         }

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -91,7 +91,7 @@ PlayerSettings:
   xboxEnableFitness: 0
   visibleInBackground: 1
   allowFullscreenSwitch: 1
-  fullscreenMode: 1
+  fullscreenMode: 3
   xboxSpeechDB: 0
   xboxEnableHeadOrientation: 0
   xboxEnableGuest: 0


### PR DESCRIPTION
**UI Changes**
- Add 'Back to Main Menu' button to passcode and avatar panels
- Reorganized both panel's UI a little bit to make room for the button

**LaunchManager.cs**
-Added `DisplayMainMenu` and `__ResetPasscodePanel` methods
- Changed the GameObject member variables to follow CamelCase naming convention

**ExpoEventManager.cs**
- Added `DisplayMainMenu` and `__ResetAvatarPanel` methods