### PR TITLE
Update Avatar Panel to use LeaveRoom and remove reference to old script

### DIFF
--- a/Assets/Photon/PhotonUtilities/PackObject/CodeGen/Editor/Resources/TypeCatalogue.asset
+++ b/Assets/Photon/PhotonUtilities/PackObject/CodeGen/Editor/Resources/TypeCatalogue.asset
@@ -18,6 +18,6 @@ MonoBehaviour:
     vals:
     - hashcode: 1161234830446200393
       filepath: Assets/Photon/PhotonUtilities\PackObject\_GeneratedPackExtensions\Pack_TestPackObject.cs
-      codegenFileWriteTime: 637489925826289648
+      codegenFileWriteTime: 637490815976859064
       localFieldCount: 2
       totalFieldCount: 2

--- a/Assets/Scenes/MainEventScene.unity
+++ b/Assets/Scenes/MainEventScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.4366756, g: 0.48427194, b: 0.5645252, a: 1}
+  m_IndirectSpecularColor: {r: 0.4366757, g: 0.48427194, b: 0.5645252, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -8402,7 +8402,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 727287417}
-        m_MethodName: DisplayMainMenu
+        m_MethodName: LeaveEvent
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Scenes/MainEventScene.unity
+++ b/Assets/Scenes/MainEventScene.unity
@@ -2081,7 +2081,6 @@ GameObject:
   - component: {fileID: 163575181}
   - component: {fileID: 163575180}
   - component: {fileID: 163575179}
-  - component: {fileID: 163575178}
   - component: {fileID: 163575177}
   m_Layer: 5
   m_Name: Dropdown
@@ -2127,18 +2126,6 @@ MonoBehaviour:
   dropdown: {fileID: 163575179}
   indexesToDisable: 00000000
   channelBox: {fileID: 7723019544791249950}
---- !u!114 &163575178
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 163575175}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4585faed2dd0ffa4bac6e87f508c65ef, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &163575179
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -9954,7 +9941,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1278522815}
-  - component: {fileID: 1278522816}
   m_Layer: 5
   m_Name: RoomList
   m_TagString: Untagged
@@ -9982,18 +9968,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1278522816
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1278522814}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4585faed2dd0ffa4bac6e87f508c65ef, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1281443243
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/ExpoEventManager.cs
+++ b/Assets/Scripts/ExpoEventManager.cs
@@ -141,22 +141,6 @@ public class ExpoEventManager : MonoBehaviourPunCallbacks {
         __mySelectedAvatar = avatar;
     }
 
-    public void DisplayMainMenu() {
-        LeaveEvent();
-        __ResetAvatarPanel();
-    }
-
-    private void __ResetAvatarPanel() {
-        AvatarPanel.SetActive(false);
-        UnselectedAvatarText.SetActive(false);
-        NameIsAvailableText.SetActive(false);
-        DuplicateNameText.SetActive(false);
-        EnterNameText.SetActive(false);
-        NameInputField.Select();
-        NameInputField.text = string.Empty;
-        __mySelectedAvatar = 2;
-    }
-
     private void __ResetEvent() {
         PhotonNetwork.Disconnect();
         PhotonNetwork.LoadLevel("EventLauncherScene");

--- a/Assets/Scripts/ExpoEventManager.cs
+++ b/Assets/Scripts/ExpoEventManager.cs
@@ -12,7 +12,6 @@ public class ExpoEventManager : MonoBehaviourPunCallbacks {
     public GameObject NameIsAvailableText;
     public GameObject EnterNameText;
     public GameObject[] listOfAvatars;
-    public InputField NameInputField;
     public static string initialName;
     public static bool isNameInputTouched;
     public static bool isNameUpdated;


### PR DESCRIPTION
**MainHallScene**
- 'Back to Main Menu' button in AvatarPanel uses `LeaveRoom` method now
- Removed components in `RoomList` GameObject that referenced no-longer-existing script

**ExpoEventManager.cs**
- Remove `DisplayMainMenu` and `__ResetAvatarPanel` methods