### PR TITLE
Updated workflows: test runner and builder are now using our own custom image

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,8 +13,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        unityVersion:
-          - 2019.4.17f1
         testMode:
           - playmode
 #          - editmode
@@ -31,7 +29,7 @@ jobs:
       - uses: game-ci/unity-test-runner@v2.0-alpha-2
         id: tests
         with:
-          unityVersion: ${{ matrix.unityVersion }}
+          customImage: 'validus00/editor:latest'
           testMode: ${{ matrix.testMode }}
           artifactsPath: ${{ matrix.testMode }}-artifacts
       - uses: actions/upload-artifact@v1
@@ -46,8 +44,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        unityVersion:
-          - 2019.4.17f1
         targetPlatform:
 #          - StandaloneOSX # Build a macOS standalone (Intel 64-bit).
 #          - StandaloneWindows # Build a Windows standalone.
@@ -73,7 +69,7 @@ jobs:
             Library-
       - uses: game-ci/unity-builder@v2.0-alpha-6
         with:
-          unityVersion: ${{ matrix.unityVersion }}
+          customImage: 'validus00/editor:latest'
           targetPlatform: ${{ matrix.targetPlatform }}
       - uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -13,8 +13,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        unityVersion:
-          - 2019.4.17f1
         testMode:
           - playmode
 #          - editmode
@@ -31,7 +29,7 @@ jobs:
       - uses: game-ci/unity-test-runner@v2.0-alpha-2
         id: tests
         with:
-          unityVersion: ${{ matrix.unityVersion }}
+          customImage: 'validus00/editor:latest'
           testMode: ${{ matrix.testMode }}
           artifactsPath: ${{ matrix.testMode }}-artifacts
       - uses: actions/upload-artifact@v1
@@ -46,8 +44,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        unityVersion:
-          - 2019.4.17f1
         targetPlatform:
 #          - StandaloneOSX # Build a macOS standalone (Intel 64-bit).
 #          - StandaloneWindows # Build a Windows standalone.
@@ -73,7 +69,7 @@ jobs:
             Library-
       - uses: game-ci/unity-builder@v2.0-alpha-6
         with:
-          unityVersion: ${{ matrix.unityVersion }}
+          customImage: 'validus00/editor:latest'
           targetPlatform: ${{ matrix.targetPlatform }}
       - uses: actions/upload-artifact@v1
         with:


### PR DESCRIPTION
### GitHub Actions workflow
- Both test runner and builder jobs are now using our own docker image which I cloned from: https://hub.docker.com/layers/unityci/editor/2019.4.19f1-webgl-0/images/sha256-bbcfac82d1d115d8bb891b4f0dd1e5c372d1beaa33541323a93145064a34996f?context=explore, and has ffmpeg already installed.
- Our docker image repo: https://hub.docker.com/r/validus00/editor

### Testing
- Pushed the commit to development branch. After the web app was built and committed, I verified that the new web app build has sound.