### PR TITLE
Implemented feature to allow users to click on channel name in message to populate channel input field. Fixed the issue that users can have identical usernames. Updated GitHub Actions workflows.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,7 +22,7 @@ jobs:
         dotnet-format --folder Assets/Tests/PlayMode/ --check
 
   testAllModes:
-    name: Test in ${{ matrix.testMode }} on version ${{ matrix.unityVersion }}
+    name: Test in ${{ matrix.testMode }}
     runs-on: ubuntu-latest
     needs: checkFormat
     strategy:
@@ -38,9 +38,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: Library
-          key: Library-
+          key: Library-${{ secrets.LIBRARY_CACHE_VERSION }}
           restore-keys: |
-            Library-
+            Library-${{ secrets.LIBRARY_CACHE_VERSION }}
       - uses: game-ci/unity-test-runner@v2.0-alpha-2
         id: tests
         with:
@@ -53,7 +53,7 @@ jobs:
           path: ${{ steps.tests.outputs.artifactsPath }}
 
   buildForSomePlatforms:
-    name: Build for ${{ matrix.targetPlatform }} on version ${{ matrix.unityVersion }}
+    name: Build for ${{ matrix.targetPlatform }}
     runs-on: ubuntu-latest
     needs: testAllModes
     strategy:
@@ -79,9 +79,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: Library
-          key: Library-{{ matrix.targetPlatform }}
+          key: Library-{{ matrix.targetPlatform }}-${{ secrets.LIBRARY_CACHE_VERSION }}
           restore-keys: |
-            Library-
+            Library-${{ secrets.LIBRARY_CACHE_VERSION }}
       - uses: game-ci/unity-builder@v2.0-alpha-6
         with:
           customImage: 'validus00/editor:latest'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,7 +40,7 @@ jobs:
           path: Library
           key: Library-${{ secrets.LIBRARY_CACHE_VERSION }}
           restore-keys: |
-            Library-${{ secrets.LIBRARY_CACHE_VERSION }}
+            Library-
       - uses: game-ci/unity-test-runner@v2.0-alpha-2
         id: tests
         with:
@@ -82,6 +82,7 @@ jobs:
           key: Library-{{ matrix.targetPlatform }}-${{ secrets.LIBRARY_CACHE_VERSION }}
           restore-keys: |
             Library-${{ secrets.LIBRARY_CACHE_VERSION }}
+            Library-
       - uses: game-ci/unity-builder@v2.0-alpha-6
         with:
           customImage: 'validus00/editor:latest'

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -22,7 +22,7 @@ jobs:
         dotnet-format --folder Assets/Tests/PlayMode/ --check
 
   testAllModes:
-    name: Test in ${{ matrix.testMode }} on version ${{ matrix.unityVersion }}
+    name: Test in ${{ matrix.testMode }}
     runs-on: ubuntu-latest
     needs: checkFormat
     strategy:
@@ -38,9 +38,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: Library
-          key: Library-
+          key: Library-${{ secrets.LIBRARY_CACHE_VERSION }}
           restore-keys: |
-            Library-
+            Library-${{ secrets.LIBRARY_CACHE_VERSION }}
       - uses: game-ci/unity-test-runner@v2.0-alpha-2
         id: tests
         with:
@@ -53,7 +53,7 @@ jobs:
           path: ${{ steps.tests.outputs.artifactsPath }}
 
   buildForSomePlatforms:
-    name: Build for ${{ matrix.targetPlatform }} on version ${{ matrix.unityVersion }}
+    name: Build for ${{ matrix.targetPlatform }}
     runs-on: ubuntu-latest
     needs: testAllModes
     strategy:
@@ -79,9 +79,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: Library
-          key: Library-{{ matrix.targetPlatform }}
+          key: Library-{{ matrix.targetPlatform }}-${{ secrets.LIBRARY_CACHE_VERSION }}
           restore-keys: |
-            Library-
+            Library-${{ secrets.LIBRARY_CACHE_VERSION }}
       - uses: game-ci/unity-builder@v2.0-alpha-6
         with:
           customImage: 'validus00/editor:latest'

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -40,7 +40,7 @@ jobs:
           path: Library
           key: Library-${{ secrets.LIBRARY_CACHE_VERSION }}
           restore-keys: |
-            Library-${{ secrets.LIBRARY_CACHE_VERSION }}
+            Library-
       - uses: game-ci/unity-test-runner@v2.0-alpha-2
         id: tests
         with:
@@ -82,6 +82,7 @@ jobs:
           key: Library-{{ matrix.targetPlatform }}-${{ secrets.LIBRARY_CACHE_VERSION }}
           restore-keys: |
             Library-${{ secrets.LIBRARY_CACHE_VERSION }}
+            Library-
       - uses: game-ci/unity-builder@v2.0-alpha-6
         with:
           customImage: 'validus00/editor:latest'

--- a/Assets/Photon/PhotonUtilities/PackObject/CodeGen/Editor/Resources/TypeCatalogue.asset
+++ b/Assets/Photon/PhotonUtilities/PackObject/CodeGen/Editor/Resources/TypeCatalogue.asset
@@ -18,6 +18,6 @@ MonoBehaviour:
     vals:
     - hashcode: 1161234830446200393
       filepath: Assets/Photon/PhotonUtilities\PackObject\_GeneratedPackExtensions\Pack_TestPackObject.cs
-      codegenFileWriteTime: 637494104819292823
+      codegenFileWriteTime: 637494250563143498
       localFieldCount: 2
       totalFieldCount: 2

--- a/Assets/Resources/Text.prefab
+++ b/Assets/Resources/Text.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &4405345945222537773
+--- !u!1 &1859685972784717751
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,23 +8,24 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 8570220517373446974}
-  - component: {fileID: 3949380429552903138}
-  - component: {fileID: 6349952137004199415}
+  - component: {fileID: 2706065528365277372}
+  - component: {fileID: 6048460933355319106}
+  - component: {fileID: 8123886522178107540}
+  - component: {fileID: 1256751381544926490}
   m_Layer: 5
-  m_Name: Text
+  m_Name: Text (TMP)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &8570220517373446974
+--- !u!224 &2706065528365277372
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4405345945222537773}
+  m_GameObject: {fileID: 1859685972784717751}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -35,26 +36,26 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 649.2401, y: 0}
+  m_SizeDelta: {x: 200, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &3949380429552903138
+--- !u!222 &6048460933355319106
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4405345945222537773}
+  m_GameObject: {fileID: 1859685972784717751}
   m_CullTransparentMesh: 0
---- !u!114 &6349952137004199415
+--- !u!114 &8123886522178107540
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4405345945222537773}
+  m_GameObject: {fileID: 1859685972784717751}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -64,17 +65,86 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 24
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 1
-    m_MaxSize: 40
-    m_Alignment: 0
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 1
-    m_LineSpacing: 1
-  m_Text: New Text
+  m_text: New Text
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 1
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: -450.4429, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &1256751381544926490
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1859685972784717751}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0400af267f5488a4898e3d766066199c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Text: {fileID: 8123886522178107540}
+  ChatManagerObject: {fileID: 0}

--- a/Assets/Resources/Text.prefab.meta
+++ b/Assets/Resources/Text.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2c61f1eb877efbe49b84ca6919cf69b4
+guid: 6e2d0b2909a3b664c8f191a77566115f
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Scenes/MainEventScene.unity
+++ b/Assets/Scenes/MainEventScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.4366757, g: 0.48427194, b: 0.5645252, a: 1}
+  m_IndirectSpecularColor: {r: 0.4366756, g: 0.48427194, b: 0.5645252, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1108,7 +1108,7 @@ RectTransform:
   m_Children:
   - {fileID: 322758113}
   m_Father: {fileID: 1231382617}
-  m_RootOrder: 11
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -2296,7 +2296,7 @@ Transform:
   m_LocalScale: {x: 1.2339332, y: 1.2339332, z: 1.2339332}
   m_Children: []
   m_Father: {fileID: 1231382617}
-  m_RootOrder: 12
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &188638073
 GameObject:
@@ -2792,7 +2792,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1231382617}
-  m_RootOrder: 13
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4171,7 +4171,7 @@ RectTransform:
   m_Children:
   - {fileID: 1888291109}
   m_Father: {fileID: 1231382617}
-  m_RootOrder: 10
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -6087,7 +6087,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   chatPanel: {fileID: 492985573996540562}
-  textObject: {fileID: 4405345945222537773, guid: 2c61f1eb877efbe49b84ca6919cf69b4,
+  TextObject: {fileID: 1859685972784717751, guid: 6e2d0b2909a3b664c8f191a77566115f,
     type: 3}
   eventInfoManagerObject: {fileID: 264550427}
   channelBox: {fileID: 7723019544791249950}
@@ -6255,7 +6255,7 @@ RectTransform:
   m_Children:
   - {fileID: 974635087}
   m_Father: {fileID: 1231382617}
-  m_RootOrder: 9
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -9487,7 +9487,7 @@ Canvas:
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 0
+  m_AdditionalShaderChannelsFlag: 25
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
@@ -9511,11 +9511,11 @@ RectTransform:
   - {fileID: 1374769115}
   - {fileID: 858258714}
   - {fileID: 1024069139}
-  - {fileID: 810531360}
   - {fileID: 488221783}
   - {fileID: 111417367}
   - {fileID: 174870138}
   - {fileID: 264550428}
+  - {fileID: 810531360}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -16180,7 +16180,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
@@ -16205,7 +16205,7 @@ MonoBehaviour:
   m_Spacing: 0
   m_ChildForceExpandWidth: 1
   m_ChildForceExpandHeight: 0
-  m_ChildControlWidth: 0
+  m_ChildControlWidth: 1
   m_ChildControlHeight: 1
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
@@ -16809,7 +16809,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 492985574018449143}
   m_HandleRect: {fileID: 492985574018449142}
   m_Direction: 2
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:

--- a/Assets/Scripts/ChannelFieldHandler.cs
+++ b/Assets/Scripts/ChannelFieldHandler.cs
@@ -1,0 +1,24 @@
+﻿using TMPro;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+public class ChannelFieldHandler : MonoBehaviour, IPointerClickHandler
+{
+    public TextMeshProUGUI Text;
+    public ChatManager ChatManagerObject;
+
+    public void OnPointerClick(PointerEventData eventData)
+    {
+        if (eventData.button == PointerEventData.InputButton.Left)
+        {
+            int linkIndex = TMP_TextUtilities.FindIntersectingLink(Text, Input.mousePosition, null);
+            if (linkIndex > -1)
+            {
+                TMP_LinkInfo linkInfo = Text.textInfo.linkInfo[linkIndex];
+                string linkId = linkInfo.GetLinkID();
+
+                ChatManagerObject.UpdateChannelInputField(linkId);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/ChannelFieldHandler.cs.meta
+++ b/Assets/Scripts/ChannelFieldHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0400af267f5488a4898e3d766066199c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ChatManager.cs
+++ b/Assets/Scripts/ChatManager.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Photon.Pun;
 using Photon.Realtime;
+using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -32,8 +33,8 @@ public class ChatManager : MonoBehaviour
     private const int __maxMessages = 100;
     // Chat panel
     public GameObject chatPanel;
-    // Text objects to populate chat panel
-    public GameObject textObject;
+    // TMP text object to populate chat panel
+    public GameObject TextObject;
     // Event info manager object to access event info manager
     public GameObject eventInfoManagerObject;
     // Event info manager to access event info owner
@@ -108,6 +109,12 @@ public class ChatManager : MonoBehaviour
         }
     }
 
+    // For updating channel input field
+    public void UpdateChannelInputField(string channelName)
+    {
+        channelBox.text = channelName;
+    }
+
     private void __processChatInput()
     {
         // Enter key either sends a message or activates the chat input field
@@ -145,7 +152,7 @@ public class ChatManager : MonoBehaviour
                         if (username == PhotonNetwork.NickName)
                         {
                             __SendMessageToChat("Cannot send message to yourself.", Message.MessageType.info);
-                            channelBox.text = string.Empty;
+                            UpdateChannelInputField(string.Empty);
                         }
                         else
                         {
@@ -158,7 +165,7 @@ public class ChatManager : MonoBehaviour
                         // Notify user that the recipient does not exist
                         __SendMessageToChat($"\"{channelName}\" does not exist in the room.",
                             Message.MessageType.info);
-                        channelBox.text = string.Empty;
+                        UpdateChannelInputField(string.Empty);
                     }
                     chatBox.text = string.Empty;
                 }
@@ -167,7 +174,7 @@ public class ChatManager : MonoBehaviour
                 {
                     // Notify user that they do not have access to announcement channel
                     __SendMessageToChat($"Only event admins have access to \"{channelName}\".", Message.MessageType.info);
-                    channelBox.text = string.Empty;
+                    UpdateChannelInputField(string.Empty);
                 }
                 else
                 {
@@ -249,10 +256,11 @@ public class ChatManager : MonoBehaviour
 
         // Create new Message object and add to list of messages
         Message message = new Message();
-        GameObject newText = Instantiate(textObject, chatPanel.transform);
+        GameObject newText = Instantiate(TextObject, chatPanel.transform);
+        newText.GetComponent<ChannelFieldHandler>().ChatManagerObject = this;
         message.MessageText = text;
         message.MsgType = messageType;
-        message.TextObject = newText.GetComponent<Text>();
+        message.TextObject = newText.GetComponent<TextMeshProUGUI>();
         message.TextObject.text = text;
         message.TextObject.color = __MessageTypeColor(messageType);
 
@@ -265,8 +273,9 @@ public class ChatManager : MonoBehaviour
         // Limit number of messages
         __LimitNumberOfMessages();
 
-        GameObject newText = Instantiate(textObject, chatPanel.transform);
-        message.TextObject = newText.GetComponent<Text>();
+        GameObject newText = Instantiate(TextObject, chatPanel.transform);
+        newText.GetComponent<ChannelFieldHandler>().ChatManagerObject = this;
+        message.TextObject = newText.GetComponent<TextMeshProUGUI>();
         message.TextObject.text = message.MessageText;
         message.TextObject.color = __MessageTypeColor(message.MsgType);
 

--- a/Assets/Scripts/ExpoEventManager.cs
+++ b/Assets/Scripts/ExpoEventManager.cs
@@ -102,9 +102,11 @@ public class ExpoEventManager : MonoBehaviourPunCallbacks
 
     private bool __IsNameAvailable()
     {
+        string name = initialName + PhotonNetwork.CurrentRoom.Name;
+
         foreach (Player player in PhotonNetwork.PlayerList)
         {
-            if (initialName.Equals(player.NickName))
+            if (name.Equals(player.NickName))
             {
                 return false;
             }

--- a/Assets/Scripts/Message.cs
+++ b/Assets/Scripts/Message.cs
@@ -1,7 +1,7 @@
 ﻿/*
  * Message class is for creating objects that hold text objects
  */
-using UnityEngine.UI;
+using TMPro;
 
 [System.Serializable]
 public class Message
@@ -14,7 +14,7 @@ public class Message
         privateMessage
     }
 
-    public Text TextObject;
+    public TextMeshProUGUI TextObject;
     public string MessageText;
     public MessageType MsgType;
 }

--- a/Assets/Scripts/PhotonChatHandler.cs
+++ b/Assets/Scripts/PhotonChatHandler.cs
@@ -158,7 +158,7 @@ public class PhotonChatHandler : IChatClientListener, IPhotonChatHandler
                 {
                     sender = senders[0];
                 }
-                string message = string.Format("[{0}] {1}: {2}", RemoveRoomName(channelName), sender, messages[0]);
+                string message = string.Format("[<link=\"{0}\">{0}</link>] {1}: {2}", RemoveRoomName(channelName), sender, messages[0]);
                 AddNewMessage(message, Message.MessageType.playerMessage);
             }
         }
@@ -179,11 +179,11 @@ public class PhotonChatHandler : IChatClientListener, IPhotonChatHandler
         string privateMessage;
         if (sender == username)
         {
-            privateMessage = string.Format("[Private] To {0}: {1}", RemoveRoomName(recipient), message.ToString());
+            privateMessage = string.Format("[Private] To <link=\"{0}\">{0}</link>: {1}", RemoveRoomName(recipient), message.ToString());
         }
         else
         {
-            privateMessage = string.Format("[Private] From {0}: {1}", RemoveRoomName(sender), message.ToString());
+            privateMessage = string.Format("[Private] From <link=\"{0}\">{0}</link>: {1}", RemoveRoomName(sender), message.ToString());
         }
         AddNewMessage(privateMessage, Message.MessageType.privateMessage);
     }
@@ -206,7 +206,7 @@ public class PhotonChatHandler : IChatClientListener, IPhotonChatHandler
                 string subscriptionMessage;
                 if (results[i])
                 {
-                    subscriptionMessage = string.Format("You entered the {0} channel.", RemoveRoomName(channels[i]));
+                    subscriptionMessage = string.Format("You entered the <link=\"{0}\">{0}</link> channel.", RemoveRoomName(channels[i]));
                 }
                 else
                 {

--- a/Assets/Tests/EditorMode/EditorMode.asmdef
+++ b/Assets/Tests/EditorMode/EditorMode.asmdef
@@ -1,8 +1,9 @@
 {
     "name": "EditorMode",
     "references": [
-        "UnityEngine.TestRunner",
+        "Unity.TextMeshPro",
         "UnityEditor.TestRunner",
+        "UnityEngine.TestRunner",
         "Scripts"
     ],
     "includePlatforms": [

--- a/Assets/Tests/PlayMode/ChatManagerTests.cs
+++ b/Assets/Tests/PlayMode/ChatManagerTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using NSubstitute;
 using NUnit.Framework;
+using TMPro;
 using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEngine.UI;
@@ -388,8 +389,9 @@ namespace Tests
             chatManager.chatPanel = chatPanel;
 
             GameObject textObject = new GameObject("Text");
-            textObject.AddComponent<Text>();
-            chatManager.textObject = textObject;
+            textObject.AddComponent<TextMeshProUGUI>();
+            textObject.AddComponent<ChannelFieldHandler>();
+            chatManager.TextObject = textObject;
 
             GameObject channelBoxObject = new GameObject("ChannelBoxObject");
             InputField channelBox = channelBoxObject.AddComponent<InputField>();

--- a/Assets/Tests/PlayMode/PlayMode.asmdef
+++ b/Assets/Tests/PlayMode/PlayMode.asmdef
@@ -1,8 +1,9 @@
 {
     "name": "PlayMode",
     "references": [
-        "UnityEngine.TestRunner",
+        "Unity.TextMeshPro",
         "UnityEditor.TestRunner",
+        "UnityEngine.TestRunner",
         "Scripts"
     ],
     "includePlatforms": [],


### PR DESCRIPTION
### ChannelFieldHandler
- This class allows text in TMP objects to be links and clickable. Once someone clicks it, it refers to the "linkId" of that embedded link. The ChannelFieldHandlerobject then calls UpdateChannelInputField method to update the channel input field.

### ChatManager
1. Updated text object reference. Text type --> TextMeshProUGUI type.
2. Added UpdateChannelInputField public method: this method updates the channel input field.

### ExpoEventManager
- Fixed the issue where users can choose a username that is already taken.

### Message
- Updated text object reference. Text type --> TextMeshProUGUI type.

### PhotonChatHandler
- Added links to the messages to allow channel names or message sender names to be referenced.

### GitHub Actions workflows
1. Updated job names: they no longer have "unityVersion" in the name.
2. Cache key name now has LIBRARY_CACHE_VERSION appended to it. This allows us to update the key version whenever we update the repository secret.

### Assets
- "Text" prefab is now a TMP object instead of Text object, and has ChannelFieldHandler attached to it.

### Unit test
- Updated ChatManagerTests.

### Testing
1. Manually tested that users cannot choose the same username if username is already taken.
2. Manually tested that users can click on the name of the channel or a message sender to automatically populate the channel input field.
3. New build: http://web.engr.oregonstate.edu/~wukev/index.html