### PR TITLE
Changed Spatial Blend from 0 to 1 in Audio Sources.

### DIFF
--- a/Assets/Photon/PhotonUtilities/PackObject/CodeGen/Editor/Resources/TypeCatalogue.asset
+++ b/Assets/Photon/PhotonUtilities/PackObject/CodeGen/Editor/Resources/TypeCatalogue.asset
@@ -18,6 +18,6 @@ MonoBehaviour:
     vals:
     - hashcode: 1161234830446200393
       filepath: Assets/Photon/PhotonUtilities\PackObject\_GeneratedPackExtensions\Pack_TestPackObject.cs
-      codegenFileWriteTime: 637497813366357010
+      codegenFileWriteTime: 637499365461807467
       localFieldCount: 2
       totalFieldCount: 2

--- a/Assets/Resources/User1.prefab
+++ b/Assets/Resources/User1.prefab
@@ -10918,7 +10918,7 @@ AudioSource:
     m_Curve:
     - serializedVersion: 3
       time: 0
-      value: 0
+      value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0

--- a/Assets/Resources/User2.prefab
+++ b/Assets/Resources/User2.prefab
@@ -10918,7 +10918,7 @@ AudioSource:
     m_Curve:
     - serializedVersion: 3
       time: 0
-      value: 0
+      value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0

--- a/Assets/Resources/User3.prefab
+++ b/Assets/Resources/User3.prefab
@@ -2476,7 +2476,7 @@ AudioSource:
     m_Curve:
     - serializedVersion: 3
       time: 0
-      value: 0
+      value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0

--- a/Assets/Resources/User4.prefab
+++ b/Assets/Resources/User4.prefab
@@ -8176,7 +8176,7 @@ AudioSource:
     m_Curve:
     - serializedVersion: 3
       time: 0
-      value: 0
+      value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0


### PR DESCRIPTION
### Prefabs
- Changed "Spatial Blend" setting in Audio Sources in User1-4: from 0 to 1. This makes it so that users will only hear footsteps of event attendees who are moving close to them, instead of those of all event attendees.

### Testing
- Manually tested sound on two users on two different computers. Was able to verify that footsteps of others start to fade after some distance.
- New build: http://web.engr.oregonstate.edu/~wukev/index.html