### PR TITLE
Fixed an issue with width of 'Text' prefab: it was overflowing the chat panel.

### DIFF
--- a/Assets/Photon/PhotonUtilities/PackObject/CodeGen/Editor/Resources/TypeCatalogue.asset
+++ b/Assets/Photon/PhotonUtilities/PackObject/CodeGen/Editor/Resources/TypeCatalogue.asset
@@ -18,6 +18,6 @@ MonoBehaviour:
     vals:
     - hashcode: 1161234830446200393
       filepath: Assets/Photon/PhotonUtilities\PackObject\_GeneratedPackExtensions\Pack_TestPackObject.cs
-      codegenFileWriteTime: 637501225871740811
+      codegenFileWriteTime: 637502277715463552
       localFieldCount: 2
       totalFieldCount: 2

--- a/Assets/Resources/Text.prefab
+++ b/Assets/Resources/Text.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 8123886522178107540}
   - component: {fileID: 1256751381544926490}
   m_Layer: 5
-  m_Name: Text (TMP)
+  m_Name: Text
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -128,7 +128,7 @@ MonoBehaviour:
   m_VertexBufferAutoSizeReduction: 1
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: -450.4429, w: 0}
+  m_margin: {x: 0, y: 0, z: 19.9768, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_hasFontAssetChanged: 0
@@ -147,4 +147,3 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Text: {fileID: 8123886522178107540}
-  ChatManagerObject: {fileID: 0}

--- a/Assets/Scenes/MainEventScene.unity
+++ b/Assets/Scenes/MainEventScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.4366757, g: 0.48427194, b: 0.5645252, a: 1}
+  m_IndirectSpecularColor: {r: 0.4366756, g: 0.48427194, b: 0.5645252, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -19724,7 +19724,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.000030517578}
+  m_AnchoredPosition: {x: 0, y: -0.000061035156}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
 --- !u!114 &492985573996540564


### PR DESCRIPTION
### Assets
- **Text** prefab instances were overflowing the chat panel whenever sent messages were very long. Therefore, its width has been reduced to fix inside the chat panel.

### Testing
- Manually tested that very long texts are no longer overflowing the chat panel.
- [New build](http://web.engr.oregonstate.edu/~wukev/index.html)