### PR TITLE
Updated classes to inherit from MonoBehaviour instead of from MonoBehavourPunCallbacks. Fixed OnCreateRoomFailed callback. Updated poster texture setting Coroutine calls to be more reliable.

### DIFF
--- a/Assets/Resources/Booth.prefab
+++ b/Assets/Resources/Booth.prefab
@@ -417,8 +417,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ec23254ed00ccb14db9d37f9aabd4089, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  BoothText: {fileID: 0}
-  PosterBoard: {fileID: 0}
+  BoothText: {fileID: 3319354799708629425}
+  PosterBoard: {fileID: 8337396069042686589}
+  DefaultPosterMaterial: {fileID: 2100000, guid: cab1fc837da6e914f80dea8c53622b65,
+    type: 2}
 --- !u!114 &143906958930633961
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/BoothSetup.cs
+++ b/Assets/Scripts/BoothSetup.cs
@@ -7,13 +7,14 @@ using UnityEngine.Networking;
 /*
  * BoothSetup class is for implementing business logic surrounding entering and leaving booths
  */
-public class BoothSetup : MonoBehaviourPunCallbacks
+public class BoothSetup : MonoBehaviour
 {
     public TextMeshProUGUI BoothText;
     public GameObject PosterBoard;
     private PanelManager _panelManager;
     private ChatManager _chatManager;
     private Camera _camera;
+    private PhotonView _photonView;
     private bool _isUserInBooth = false;
     private string _boothOwner;
     private string _projectName;
@@ -25,6 +26,7 @@ public class BoothSetup : MonoBehaviourPunCallbacks
     {
         _panelManager = GameObject.Find(GameConstants.K_PanelManager).GetComponent<PanelManager>();
         _chatManager = GameObject.Find(GameConstants.K_ExpoEventManager).GetComponent<ChatManager>();
+        _photonView = GetComponent<PhotonView>();
     }
 
     // This is called when the user first enters a booth area
@@ -91,7 +93,7 @@ public class BoothSetup : MonoBehaviourPunCallbacks
     {
         if (string.IsNullOrEmpty(_projectName))
         {
-            photonView.RPC("SyncBooth", RpcTarget.AllBuffered, PhotonNetwork.NickName, projectName, teamName,
+            _photonView.RPC("SyncBooth", RpcTarget.AllBuffered, PhotonNetwork.NickName, projectName, teamName,
                 projectDescription, projectUrl, posterUrl);
             return true;
         }
@@ -145,7 +147,7 @@ public class BoothSetup : MonoBehaviourPunCallbacks
     // For handling booth info reset logic
     public void ResetBooth()
     {
-        photonView.RPC("ClearBooth", RpcTarget.AllBuffered);
+        _photonView.RPC("ClearBooth", RpcTarget.AllBuffered);
     }
 
     // PRC for resetting booth

--- a/Assets/Scripts/BoothSetup.cs
+++ b/Assets/Scripts/BoothSetup.cs
@@ -11,6 +11,7 @@ public class BoothSetup : MonoBehaviour
 {
     public TextMeshProUGUI BoothText;
     public GameObject PosterBoard;
+    public Material DefaultPosterMaterial;
     private PanelManager _panelManager;
     private ChatManager _chatManager;
     private Camera _camera;
@@ -21,12 +22,23 @@ public class BoothSetup : MonoBehaviour
     private string _teamName;
     private string _projectDescription;
     private string _projectUrl;
+    private string _posterUrl;
+    private bool _posterUpdated = false;
 
     void Start()
     {
         _panelManager = GameObject.Find(GameConstants.K_PanelManager).GetComponent<PanelManager>();
         _chatManager = GameObject.Find(GameConstants.K_ExpoEventManager).GetComponent<ChatManager>();
         _photonView = GetComponent<PhotonView>();
+    }
+
+    void Update()
+    {
+        if (!string.IsNullOrWhiteSpace(_posterUrl) && !_posterUpdated && ExpoEventManager.IsNameUpdated)
+        {
+            StartCoroutine(SetPosterTexture(_posterUrl));
+            _posterUpdated = true;
+        }
     }
 
     // This is called when the user first enters a booth area
@@ -123,25 +135,26 @@ public class BoothSetup : MonoBehaviour
         string projectUrl, string posterUrl)
     {
         BoothText.text = projectName;
-        AssignBoothValues(boothOwner, projectName, teamName, projectDescription, projectUrl);
+        AssignBoothValues(boothOwner, projectName, teamName, projectDescription, projectUrl, posterUrl);
         if (_isUserInBooth)
         {
             JoinChannel();
         }
-        if (!string.IsNullOrWhiteSpace(posterUrl))
+        if (ExpoEventManager.IsNameUpdated && !string.IsNullOrWhiteSpace(posterUrl))
         {
             StartCoroutine(SetPosterTexture(posterUrl));
         }
     }
 
     private void AssignBoothValues(string boothOwner, string projectName, string teamName, string projectDescription,
-        string url)
+        string projectUrl, string posterUrl)
     {
         _boothOwner = boothOwner;
         _projectName = projectName;
         _teamName = teamName;
         _projectDescription = projectDescription;
-        _projectUrl = url;
+        _projectUrl = projectUrl;
+        _posterUrl = posterUrl;
     }
 
     // For handling booth info reset logic
@@ -159,7 +172,10 @@ public class BoothSetup : MonoBehaviour
             LeaveChannel();
         }
         BoothText.text = string.Empty;
-        AssignBoothValues(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty);
-        StartCoroutine(SetPosterTexture("https://i.imgur.com/EFfwKyC.png"));
+        AssignBoothValues(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty);
+        if (ExpoEventManager.IsNameUpdated)
+        {
+            PosterBoard.GetComponent<MeshRenderer>().material = DefaultPosterMaterial;
+        }
     }
 }

--- a/Assets/Scripts/EventInfoManager.cs
+++ b/Assets/Scripts/EventInfoManager.cs
@@ -1,9 +1,10 @@
 ﻿using Photon.Pun;
 using UnityEngine;
 
-public class EventInfoManager : MonoBehaviourPunCallbacks, IEventInfoManager
+public class EventInfoManager : MonoBehaviour, IEventInfoManager
 {
     private PanelManager _panelManager;
+    private PhotonView _photonView;
     private string _eventInfoUrl;
     private string _scheduleUrl;
     private string _zoomUrl;
@@ -13,6 +14,7 @@ public class EventInfoManager : MonoBehaviourPunCallbacks, IEventInfoManager
     void Start()
     {
         _panelManager = GameObject.Find(GameConstants.K_PanelManager).GetComponent<PanelManager>();
+        _photonView = GetComponent<PhotonView>();
     }
 
     public string EventInfoOwner
@@ -40,7 +42,7 @@ public class EventInfoManager : MonoBehaviourPunCallbacks, IEventInfoManager
     {
         if (string.IsNullOrEmpty(_eventInfoUrl))
         {
-            photonView.RPC("SyncEventInfo", RpcTarget.AllBuffered, eventInfoUrl, scheduleUrl, zoomUrl,
+            _photonView.RPC("SyncEventInfo", RpcTarget.AllBuffered, eventInfoUrl, scheduleUrl, zoomUrl,
                 PhotonNetwork.NickName);
             return true;
         }
@@ -59,7 +61,7 @@ public class EventInfoManager : MonoBehaviourPunCallbacks, IEventInfoManager
 
     public void ResetEventInfo()
     {
-        photonView.RPC("ClearEventInfo", RpcTarget.AllBuffered);
+        _photonView.RPC("ClearEventInfo", RpcTarget.AllBuffered);
     }
 
     // PRC for resetting event info panel data

--- a/Assets/Scripts/InfoBoothSetup.cs
+++ b/Assets/Scripts/InfoBoothSetup.cs
@@ -1,10 +1,9 @@
-﻿using Photon.Pun;
-using UnityEngine;
+﻿using UnityEngine;
 
 /*
  * InfoBoothSetup class is for implementing business logic surrounding event information
  */
-public class InfoBoothSetup : MonoBehaviourPunCallbacks
+public class InfoBoothSetup : MonoBehaviour
 {
     private Camera _camera;
     private EventInfoManager _eventInfoManager;

--- a/Assets/Scripts/LaunchManager.cs
+++ b/Assets/Scripts/LaunchManager.cs
@@ -112,14 +112,6 @@ public class LaunchManager : MonoBehaviourPunCallbacks
         Debug.Log($"Creating room with name: {randomRoomName}");
     }
 
-    // This callback is called if the randomly generated room name is identical to one that is already used by an
-    // existing room
-    public void OnCreateRoomFailed()
-    {
-        Debug.Log("Create room failed");
-        CreateAndJoinRoom();
-    }
-
     private int GenerateRandomDigits()
     {
         return Random.Range(1000, 9999);
@@ -165,6 +157,14 @@ public class LaunchManager : MonoBehaviourPunCallbacks
         }
     }
 
+    // This callback is called if the randomly generated room name is identical to one that is already used by an
+    // existing room
+    public override void OnCreateRoomFailed(short returnCode, string message)
+    {
+        Debug.Log($"Create room failed: {message} - code {returnCode}");
+        CreateAndJoinRoom();
+    }
+
     // This method is called when we have internet connection (before OnConnectedToMaster)
     public override void OnConnected()
     {
@@ -174,7 +174,7 @@ public class LaunchManager : MonoBehaviourPunCallbacks
     // Called when PhotonNetwork.JoinRoom fails
     public override void OnJoinRoomFailed(short returnCode, string message)
     {
-        Debug.Log("joined room failed");
+        Debug.Log($"Joined room failed: {message} - code {returnCode}");
         InvalidPasscodeText.SetActive(true);
     }
 

--- a/Assets/Scripts/Message.cs
+++ b/Assets/Scripts/Message.cs
@@ -3,7 +3,6 @@
  */
 using TMPro;
 
-[System.Serializable]
 public class Message
 {
     // For displaying text in chat in different colors depending on type of message 

--- a/Assets/Scripts/UserSetup.cs
+++ b/Assets/Scripts/UserSetup.cs
@@ -5,17 +5,19 @@ using UnityEngine;
 /*
  * UserSetup class implements user specific features
  */
-public class UserSetup : MonoBehaviourPunCallbacks
+public class UserSetup : MonoBehaviour
 {
     public GameObject FpsCamera;
     public TextMeshProUGUI UserNameText;
     public GameObject User;
     private CharacterController _characterController;
+    private PhotonView _photonView;
 
     // Start is called before the first frame update
     void Start()
     {
-        if (!photonView.IsMine)
+        _photonView = GetComponent<PhotonView>();
+        if (!_photonView.IsMine)
         {
             Destroy(GetComponent<MovementController>());
             Destroy(FpsCamera);
@@ -37,9 +39,9 @@ public class UserSetup : MonoBehaviourPunCallbacks
 
     private void SetUserUI()
     {
-        if (UserNameText != null && photonView.Owner != null)
+        if (UserNameText != null && _photonView.Owner != null)
         {
-            UserNameText.text = PhotonChatHandler.RemoveRoomName(photonView.Owner.NickName);
+            UserNameText.text = PhotonChatHandler.RemoveRoomName(_photonView.Owner.NickName);
         }
     }
 
@@ -51,7 +53,7 @@ public class UserSetup : MonoBehaviourPunCallbacks
         {
             _characterController = GetComponent<CharacterController>();
         }
-        if (!photonView.IsMine)
+        if (!_photonView.IsMine)
         {
             _characterController.enabled = value;
         }


### PR DESCRIPTION
### BoothSetup
- Added a private field for poster image URL.
- Updated when `SetPosterTexture` is called:
   - `SetPosterTexture` will no longer always be called by the RPC target method. Instead, the RPC target method will first check if the user has already properly logged into the event (after choosing their username and avatar) before calling `SetPosterTexture`. This change means that whenever someone sets up a booth, the poster image updates will continue to work like before and will always update for users who are already in the event. This behavior is not changed.
   - For new user who log in and receives RPCs: the target methods won't update the poster image every time it is called. Instead, after the user logs in (after choosing their username and avatar), the first `Update` will update the poster image based on the latest saved poster URL.
   - This change is a response to the fact that, while RPCs are queued and are executed in sequence, the poster image update coroutine can finish at different times depending on the size of the image. For example, if we were to set the poster texture with a large image file, and then reset the booth, sometimes users will log in and see the non-default poster texture, even though the booth has been reset.
- Updated `ClearBooth`: it no longer needs to load the default poster image from the internet and will load the default poster texture from memory instead.

### LaunchManager
- `OnCreateRoomFailed` callback was improperly implemented. It didn't have `override` modifier and didn't have the correct method signature (was missing parameters that the method it was overriding had).

### Misc
- Updated **BoothSetup**, **EventInfoManager**, **UserSetup** to no longer inherit from MonoBehaviourPunCallBacks and to inherit from MonoBehaviour instead. These classes also now call `GetComponent` to get PhotonView component.

### Testing
- Re-ran unit tests.
- Re-ran dotnet-format.
- Manually tested that booth setup is working as intended: if a booth is reset multiple times, newly arrived users will see the correct poster texture.
- [New build](https://web.engr.oregonstate.edu/~wukev/index.html)
